### PR TITLE
Fix ‘u_int64_t’ undeclared

### DIFF
--- a/bcl/src/bc_onewire.c
+++ b/bcl/src/bc_onewire.c
@@ -86,7 +86,7 @@ void bc_onewire_select(bc_gpio_channel_t channel, uint64_t *device_number)
     {
         _bc_onewire_write_byte(channel, 0x55);
 
-        for (size_t i = 0; i < sizeof(u_int64_t); i++)
+        for (size_t i = 0; i < sizeof(uint64_t); i++)
         {
             _bc_onewire_write_byte(channel, ((uint8_t *) device_number)[i]);
         }


### PR DESCRIPTION
Fix for compilation error:

````
Compiling: sdk/bcl/src/bc_onewire.c
sdk/bcl/src/bc_onewire.c: In function ‘bc_onewire_select’:
sdk/bcl/src/bc_onewire.c:59:39: error: ‘u_int64_t’ undeclared (first use in this function)
         for (size_t i = 0; i < sizeof(u_int64_t); i++)
                                       ^~~~~~~~~
sdk/bcl/src/bc_onewire.c:59:39: note: each undeclared identifier is reported only once for each function it appears in
make[1]: *** [sdk/Makefile.mk:334: obj/debug/sdk/bcl/src/bc_onewire.o] Chyba 1
make: *** [sdk/Makefile.mk:166: debug] Chyba 2
````