### PR TITLE
Add helper function for button pairing

### DIFF
--- a/bcl/inc/bc_radio.h
+++ b/bcl/inc/bc_radio.h
@@ -57,6 +57,6 @@ bool bc_radio_pub_co2(float *concentration);
 
 bool bc_radio_pub_buffer(void *buffer, size_t length);
 
-void bc_radio_button_pair(bc_button_t *button, bc_led_t *led);
+void bc_radio_init_pairing_button();
 
 #endif // _BC_RADIO_H

--- a/bcl/inc/bc_radio.h
+++ b/bcl/inc/bc_radio.h
@@ -2,6 +2,8 @@
 #define _BC_RADIO_H
 
 #include <bc_common.h>
+#include <bc_button.h>
+#include <bc_led.h>
 
 #ifndef BC_RADIO_MAX_DEVICES
 #define BC_RADIO_MAX_DEVICES 8
@@ -54,5 +56,7 @@ bool bc_radio_pub_barometer(uint8_t i2c, float *pascal, float *meter);
 bool bc_radio_pub_co2(float *concentration);
 
 bool bc_radio_pub_buffer(void *buffer, size_t length);
+
+void bc_radio_button_pair(bc_button_t *button, bc_led_t *led);
 
 #endif // _BC_RADIO_H

--- a/bcl/src/bc_radio.c
+++ b/bcl/src/bc_radio.c
@@ -716,12 +716,11 @@ static bool _bc_radio_peer_device_remove(uint64_t device_address)
 void _bc_radio_button_event_handler(bc_button_t *self, bc_button_event_t event, void *event_param)
 {
     (void) self;
-    (void) event_param;
-    bc_led_t *led = (bc_led_t*)event_param;
+    bc_led_t *led = (bc_led_t*) event_param;
 
     if (event == BC_BUTTON_EVENT_PRESS)
     {
-        if(led)
+        if (led != NULL)
         {
             bc_led_pulse(led, 100);
         }
@@ -736,7 +735,7 @@ void _bc_radio_button_event_handler(bc_button_t *self, bc_button_event_t event, 
     {
         bc_radio_enroll_to_gateway();
 
-        if(led)
+        if (led != NULL)
         {
             bc_led_set_mode(led, BC_LED_MODE_OFF);
             bc_led_pulse(led, 1000);
@@ -744,16 +743,15 @@ void _bc_radio_button_event_handler(bc_button_t *self, bc_button_event_t event, 
     }
 }
 
-void bc_radio_button_pair(bc_button_t *button, bc_led_t *led)
+void bc_radio_init_pairing_button()
 {
-    // Init button and callback
-    bc_button_init(button, BC_GPIO_BUTTON, BC_GPIO_PULL_DOWN, false);
-    // Pass led instance as a callback parameter, so we don't need to add it to the radio structure
-    bc_button_set_event_handler(button, _bc_radio_button_event_handler, led);
+    static bc_led_t led;
+    static bc_button_t button;
 
-    // Parameter led can be NULL
-    if(led)
-    {
-        bc_led_init(led, BC_GPIO_LED, false, false);
-    }
+    bc_button_init(&button, BC_GPIO_BUTTON, BC_GPIO_PULL_DOWN, 0);
+    // Pass led instance as a callback parameter, so we don't need to add it to the radio structure
+    bc_button_set_event_handler(&button, _bc_radio_button_event_handler, &led);
+
+    bc_led_init(&led, BC_GPIO_LED, false, 0);
+
 }

--- a/bcl/src/bc_radio.c
+++ b/bcl/src/bc_radio.c
@@ -711,3 +711,49 @@ static bool _bc_radio_peer_device_remove(uint64_t device_address)
 
 	return false;
 }
+
+
+void _bc_radio_button_event_handler(bc_button_t *self, bc_button_event_t event, void *event_param)
+{
+    (void) self;
+    (void) event_param;
+    bc_led_t *led = (bc_led_t*)event_param;
+
+    if (event == BC_BUTTON_EVENT_PRESS)
+    {
+        if(led)
+        {
+            bc_led_pulse(led, 100);
+        }
+
+        static uint16_t event_count = 0;
+
+        bc_radio_pub_push_button(&event_count);
+
+        event_count++;
+    }
+    else if (event == BC_BUTTON_EVENT_HOLD)
+    {
+        bc_radio_enroll_to_gateway();
+
+        if(led)
+        {
+            bc_led_set_mode(led, BC_LED_MODE_OFF);
+            bc_led_pulse(led, 1000);
+        }
+    }
+}
+
+void bc_radio_button_pair(bc_button_t *button, bc_led_t *led)
+{
+    // Init button and callback
+    bc_button_init(button, BC_GPIO_BUTTON, BC_GPIO_PULL_DOWN, false);
+    // Pass led instance as a callback parameter, so we don't need to add it to the radio structure
+    bc_button_set_event_handler(button, _bc_radio_button_event_handler, led);
+
+    // Parameter led can be NULL
+    if(led)
+    {
+        bc_led_init(led, BC_GPIO_LED, false, false);
+    }
+}


### PR DESCRIPTION
Now the user creating remote firmware needs just to call:
application_init()
{
bc_radio_init();
bc_radio_button_pair(&button, &led);
}
There is no need to init button or led instance or set-up button callbacks with calls to bc_radio_enroll() in application.c anymore.

I'm not sure if this code should be in bc_radio, because I had to add bc_button.h and bc_led.h dependencies to the bc_radio.h. I would welcome any idea. Maybe it is time for bc_helper.c file, where these helping functions should belong?